### PR TITLE
Fix: Add Windows fallback for uvloop to asyncio

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -43,7 +43,7 @@ dev = [
 api = [
     "fastapi>=0.100.0",
     "uvicorn[standard]>=0.22.0",
-    "uvloop>=0.17.0",
+    "uvloop>=0.17.0 ; sys_platform != 'win32' and platform_system != 'Windows'",
     "httptools>=0.6.0",
 ]
 production = [

--- a/backend/src/server.py
+++ b/backend/src/server.py
@@ -2,6 +2,7 @@
 Production server startup script
 """
 
+import platform
 import uvicorn
 
 from src.config.settings import get_settings
@@ -16,13 +17,19 @@ def main():
 
     # Additional production optimizations
     if settings.is_production:
-        config.update(
-            {
-                "loop": "uvloop",  # Use uvloop for better performance
-                "http": "httptools",  # Use httptools for better HTTP parsing
-                "interface": "asgi3",  # Use ASGI3 interface
-            }
-        )
+        updates = {
+            "http": "httptools",  # Use httptools for better HTTP parsing
+            "interface": "asgi3",  # Use ASGI3 interface
+        }
+        
+        # Use uvloop on non-Windows platforms for better performance
+        if platform.system() != "Windows":
+            updates["loop"] = "uvloop"
+        else:
+            # Use asyncio on Windows
+            updates["loop"] = "asyncio"
+        
+        config.update(updates)
 
     # Start server
     uvicorn.run("main:app", **config)


### PR DESCRIPTION
## Summary
- Adds Windows compatibility by falling back to asyncio when uvloop is not available
- Makes uvloop dependency conditional in pyproject.toml (non-Windows platforms only)
- Updates server.py to detect platform and use appropriate event loop

## Problem
The application fails to install on Windows because uvloop does not support Windows. This prevents Windows users from running the haptic generator system.

## Solution
- Added platform condition to uvloop dependency: `sys_platform \!= 'win32' and platform_system \!= 'Windows'`
- Added runtime platform detection in server.py to use asyncio on Windows
- Maintains uvloop performance benefits on Unix-like systems

## Test Plan
- [ ] Verify installation works on Windows without uvloop errors
- [ ] Confirm uvloop is still used on Linux/macOS for performance
- [ ] Test that the server starts correctly on both platforms

🤖 Generated with [Claude Code](https://claude.ai/code)