### PR TITLE
Hotfix: フロントエンドからYURAGIモードのdevice_id選択を削除

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -74,7 +74,7 @@ function HapticApp() {
             <>
               <HapticControlPanel isSingleDeviceMode={isSingleDeviceMode} />
               <div style={{ marginTop: '20px' }}>
-                <YURAGIControl deviceId={1} />
+                <YURAGIControl />
               </div>
             </>
           )}

--- a/frontend/src/services/hapticService.ts
+++ b/frontend/src/services/hapticService.ts
@@ -87,7 +87,6 @@ export class HapticService {
   // YURAGI massage control
   static async yuragiPreset(params: IYURAGIRequest): Promise<IYURAGIStatus> {
     const response = await api.post('/yuragi/preset', {
-      device_id: params.deviceId,
       preset: params.preset,
       duration: params.duration,
       enabled: params.enabled,

--- a/frontend/src/types/hapticTypes.ts
+++ b/frontend/src/types/hapticTypes.ts
@@ -67,7 +67,6 @@ export const CHANNEL_IDS = {
 
 // YURAGI massage control types
 export interface IYURAGIRequest {
-  deviceId: 1 | 2
   preset: 'gentle' | 'moderate' | 'intense' | 'therapeutic' | 'therapeutic_fluctuation'
   duration: number // in seconds, 30-300
   enabled: boolean


### PR DESCRIPTION
## 概要
バックエンドでYURAGIモードが両デバイスを同時に制御するよう変更されたため（PR #16）、フロントエンドも対応する修正を実施しました。

## 問題
PR #16のマージ後、フロントエンドがまだdevice_id選択UIを表示していて、実際の動作と一致していませんでした。

## 解決策
1. **YURAGIControlコンポーネントの修正**
   - deviceIdプロパティを削除
   - デバイス選択UIを削除

2. **API呼び出しの更新**
   - IYURAGIRequestタイプからdeviceIdフィールドを削除
   - hapticService.tsのAPIリクエストからdevice_idを削除

3. **両デバイス同時制御の実装**
   - vectorForceを両デバイス（1と2）に送信
   - progressを両デバイスで更新
   - statusを両デバイスで管理

## テスト結果
- ✅ TypeScript型チェック: パス
- ✅ ビルド: 成功
- ⚠️ テスト: 一部のテストが新しい仕様に未対応（別途修正予定）

## 影響
- YURAGIモードでは常に両方の4chデバイスが同時に動作
- デバイス選択が不要になり、よりシンプルなUIに
- Device1とDevice2が対称的に動作し、効果的な触覚フィードバックを実現

## 今後の作業
- [ ] YURAGIControl.test.tsxを新しい仕様に合わせて更新

🤖 Generated with [Claude Code](https://claude.ai/code)