### PR TITLE
Fix: YURAGI animator support for 2-channel devices

### DIFF
--- a/backend/src/haptic_system/yuragi_animator.py
+++ b/backend/src/haptic_system/yuragi_animator.py
@@ -43,7 +43,11 @@ class YURAGIAnimator:
     speed and amplitude modulation for therapeutic effects.
     """
 
-    def __init__(self, update_callback: Callable[[dict[str, Any]], None], available_channels: int = 4):
+    def __init__(
+        self,
+        update_callback: Callable[[dict[str, Any]], None],
+        available_channels: int = 4,
+    ):
         """
         Initialize YURAGI animator.
 

--- a/backend/src/haptic_system/yuragi_animator.py
+++ b/backend/src/haptic_system/yuragi_animator.py
@@ -43,15 +43,17 @@ class YURAGIAnimator:
     speed and amplitude modulation for therapeutic effects.
     """
 
-    def __init__(self, update_callback: Callable[[dict[str, Any]], None]):
+    def __init__(self, update_callback: Callable[[dict[str, Any]], None], available_channels: int = 4):
         """
         Initialize YURAGI animator.
 
         Args:
             update_callback: Callback function to update vector force
+            available_channels: Number of available channels (2 or 4)
         """
         self.logger = get_logger(self.__class__.__name__)
         self.update_callback = update_callback
+        self.available_channels = available_channels
 
         # Animation state
         self._active_animations: dict[int, asyncio.Task] = {}
@@ -119,7 +121,7 @@ class YURAGIAnimator:
 
     async def start_animation(self, preset: str, duration: float) -> None:
         """
-        Start YURAGI animation for both devices.
+        Start YURAGI animation for available devices.
 
         Args:
             preset: Preset name
@@ -131,8 +133,12 @@ class YURAGIAnimator:
         # Get preset configuration
         config = self._presets.get(preset, self._presets["default"])
 
-        # Start animation tasks for both devices
-        for device_id in [1, 2]:
+        # Determine which devices to animate based on available channels
+        device_ids = [1] if self.available_channels < 4 else [1, 2]
+        device_desc = "device 1" if self.available_channels < 4 else "both devices"
+
+        # Start animation tasks for available devices
+        for device_id in device_ids:
             self._animation_configs[device_id] = config
             task = asyncio.create_task(
                 self._animate_device(device_id, config, duration)
@@ -140,7 +146,7 @@ class YURAGIAnimator:
             self._active_animations[device_id] = task
 
         self.logger.info(
-            f"Started YURAGI animation for both devices "
+            f"Started YURAGI animation for {device_desc} "
             f"with preset '{preset}' for {duration}s"
         )
 

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -37,9 +37,9 @@ try:
         f"HapticController initialized with sample_rate={settings.sample_rate}, block_size={settings.block_size}"
     )
 
-    # Initialize YURAGI animator
-    yuragi_animator = YURAGIAnimator(controller.set_vector_force)
-    logger.info("YURAGIAnimator initialized")
+    # Initialize YURAGI animator with available channels
+    yuragi_animator = YURAGIAnimator(controller.set_vector_force, controller.available_channels)
+    logger.info(f"YURAGIAnimator initialized with {controller.available_channels} channels")
 
 except Exception as e:
     # sounddeviceがない環境では None のまま
@@ -65,8 +65,8 @@ async def lifespan(app: FastAPI):
 
             # Initialize YURAGI animator if controller is available
             if yuragi_animator is None:
-                yuragi_animator = YURAGIAnimator(controller.set_vector_force)
-                logger.info("YURAGIAnimator initialized in lifespan")
+                yuragi_animator = YURAGIAnimator(controller.set_vector_force, controller.available_channels)
+                logger.info(f"YURAGIAnimator initialized in lifespan with {controller.available_channels} channels")
 
         except Exception as e:
             logger.error(f"Failed to initialize HapticController: {e}")

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -38,8 +38,12 @@ try:
     )
 
     # Initialize YURAGI animator with available channels
-    yuragi_animator = YURAGIAnimator(controller.set_vector_force, controller.available_channels)
-    logger.info(f"YURAGIAnimator initialized with {controller.available_channels} channels")
+    yuragi_animator = YURAGIAnimator(
+        controller.set_vector_force, controller.available_channels
+    )
+    logger.info(
+        f"YURAGIAnimator initialized with {controller.available_channels} channels"
+    )
 
 except Exception as e:
     # sounddeviceがない環境では None のまま
@@ -65,8 +69,12 @@ async def lifespan(app: FastAPI):
 
             # Initialize YURAGI animator if controller is available
             if yuragi_animator is None:
-                yuragi_animator = YURAGIAnimator(controller.set_vector_force, controller.available_channels)
-                logger.info(f"YURAGIAnimator initialized in lifespan with {controller.available_channels} channels")
+                yuragi_animator = YURAGIAnimator(
+                    controller.set_vector_force, controller.available_channels
+                )
+                logger.info(
+                    f"YURAGIAnimator initialized in lifespan with {controller.available_channels} channels"
+                )
 
         except Exception as e:
             logger.error(f"Failed to initialize HapticController: {e}")


### PR DESCRIPTION
## Summary
- Fixed YURAGI animator to support 2-channel audio devices (e.g., AirPods)
- Prevents 400 Bad Request errors when device2 is not available
- Animator now only uses device1 when running on 2-channel systems

## Changes
- Added `available_channels` parameter to YURAGIAnimator constructor
- Modified `start_animation()` to only animate available devices
- Updated main.py to pass channel count from controller to animator

## Test plan
- [x] Start backend with 2-channel device (AirPods)
- [x] Open frontend and enable YURAGI mode
- [x] Verify no 400 errors occur
- [x] Stop YURAGI mode and verify clean shutdown
- [ ] Test with 4-channel device to ensure both devices still work

🤖 Generated with [Claude Code](https://claude.ai/code)