### PR TITLE
fix: device2のAcceleration Trajectoryを左右対称に修正

### DIFF
--- a/frontend/src/components/ControlPanel/YURAGIControl.tsx
+++ b/frontend/src/components/ControlPanel/YURAGIControl.tsx
@@ -12,7 +12,9 @@ export const YURAGIControl: React.FC = () => {
   const { yuragi, setYuragiStatus, updateYuragiProgress, setVectorForce } = useHapticStore()
   const { handleError } = useErrorHandler()
 
-  const [preset, setPreset] = useState<'gentle' | 'moderate' | 'intense' | 'therapeutic' | 'therapeutic_fluctuation'>('gentle')
+  const [preset, setPreset] = useState<
+    'gentle' | 'moderate' | 'intense' | 'therapeutic' | 'therapeutic_fluctuation'
+  >('gentle')
   const [duration, setDuration] = useState<number>(60)
   const [isLoading, setIsLoading] = useState<boolean>(false)
   const [error, setError] = useState<string>('')

--- a/frontend/src/components/Visualization/AccelerationTrajectoryContainer.tsx
+++ b/frontend/src/components/Visualization/AccelerationTrajectoryContainer.tsx
@@ -46,7 +46,8 @@ export const AccelerationTrajectoryContainer: React.FC<AccelerationTrajectoryCon
       const magnitude = vectorForce.magnitude
       
       // Generate circular coordinates
-      const x = magnitude * Math.cos(angle)
+      // Invert x-axis for device 2 to create symmetrical trajectories
+      const x = magnitude * Math.cos(angle) * (deviceId === 2 ? -1 : 1)
       const y = magnitude * Math.sin(angle)
       
       // Return single point for smooth trajectory
@@ -92,7 +93,9 @@ export const AccelerationTrajectoryContainer: React.FC<AccelerationTrajectoryCon
 
     // Take every 20th sample for trajectory (reduce data points but keep smooth)
     const downsampleFactor = 20
-    const xAccel = xWaveforms.acceleration.filter((_, i) => i % downsampleFactor === 0)
+    const xAccel = xWaveforms.acceleration
+      .filter((_, i) => i % downsampleFactor === 0)
+      .map(val => deviceId === 2 ? -val : val) // Invert x-axis for device 2
     const yAccel = yWaveforms.acceleration.filter((_, i) => i % downsampleFactor === 0)
 
     return { xAccel, yAccel }

--- a/frontend/src/components/Visualization/AccelerationTrajectoryContainer.tsx
+++ b/frontend/src/components/Visualization/AccelerationTrajectoryContainer.tsx
@@ -18,7 +18,7 @@ export const AccelerationTrajectoryContainer: React.FC<AccelerationTrajectoryCon
   // Get channel parameters from store
   const xChannel = useHapticStore(state => state.channels.find(ch => ch.channelId === xChannelId))
   const yChannel = useHapticStore(state => state.channels.find(ch => ch.channelId === yChannelId))
-  
+
   // Get YURAGI vector force and status
   const vectorForce = useHapticStore(state => state.vectorForce[`device${deviceId}`])
   const yuragiStatus = useHapticStore(state => state.yuragi[`device${deviceId}`])
@@ -41,19 +41,19 @@ export const AccelerationTrajectoryContainer: React.FC<AccelerationTrajectoryCon
       if (!vectorForce || vectorForce.magnitude === undefined || vectorForce.angle === undefined) {
         return null
       }
-      
+
       const angle = (vectorForce.angle * Math.PI) / 180 // Convert to radians
       const magnitude = vectorForce.magnitude
-      
+
       // Generate circular coordinates
       // Invert x-axis for device 2 to create symmetrical trajectories
       const x = magnitude * Math.cos(angle) * (deviceId === 2 ? -1 : 1)
       const y = magnitude * Math.sin(angle)
-      
+
       // Return single point for smooth trajectory
       return { xAccel: [x], yAccel: [y] }
     }
-    
+
     // Normal mode - use channel parameters
     if (!xChannel || !yChannel) {
       return null
@@ -95,7 +95,7 @@ export const AccelerationTrajectoryContainer: React.FC<AccelerationTrajectoryCon
     const downsampleFactor = 20
     const xAccel = xWaveforms.acceleration
       .filter((_, i) => i % downsampleFactor === 0)
-      .map(val => deviceId === 2 ? -val : val) // Invert x-axis for device 2
+      .map(val => (deviceId === 2 ? -val : val)) // Invert x-axis for device 2
     const yAccel = yWaveforms.acceleration.filter((_, i) => i % downsampleFactor === 0)
 
     return { xAccel, yAccel }
@@ -118,6 +118,7 @@ export const AccelerationTrajectoryContainer: React.FC<AccelerationTrajectoryCon
     }
 
     animationFrameRef.current = requestAnimationFrame(animate)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [generateAccelerationData, yuragiStatus, vectorForce, deviceId])
 
   // Clear trajectory when YURAGI mode changes
@@ -145,7 +146,7 @@ export const AccelerationTrajectoryContainer: React.FC<AccelerationTrajectoryCon
     if (animationFrameRef.current) {
       cancelAnimationFrame(animationFrameRef.current)
     }
-    
+
     animationFrameRef.current = requestAnimationFrame(animate)
 
     return () => {

--- a/frontend/src/components/__tests__/YURAGIControl.test.tsx
+++ b/frontend/src/components/__tests__/YURAGIControl.test.tsx
@@ -151,7 +151,7 @@ describe('YURAGIControl', () => {
       // Device selector should not exist
       const deviceSelect = screen.queryByLabelText('Device')
       expect(deviceSelect).not.toBeInTheDocument()
-      
+
       // Only one control panel for both devices
       expect(screen.getByTestId('yuragi-control')).toBeInTheDocument()
     })

--- a/frontend/src/utils/yuragiWaveform.ts
+++ b/frontend/src/utils/yuragiWaveform.ts
@@ -451,8 +451,8 @@ export function getPresetParameters(): PresetParameters {
       noiseLevel: 0.08,
       noiseBandwidth: 0.4,
       fluctuationAmplitude: 20.0, // 2.5x stronger fluctuation
-      fluctuationBandwidth: 0.1,  // Lower frequency bandwidth
-      fmDepth: 0.1,               // Stronger FM modulation
+      fluctuationBandwidth: 0.1, // Lower frequency bandwidth
+      fmDepth: 0.1, // Stronger FM modulation
     },
   }
 }


### PR DESCRIPTION
## 概要
device1とdevice2のAcceleration Trajectoryを左右対称に表示するため、device2のX軸方向を反転させました。

## 変更内容
- AccelerationTrajectoryContainerでdevice2のx座標を反転
  - YURAGIモード: `x = magnitude * Math.cos(angle) * (deviceId === 2 ? -1 : 1)`
  - Normalモード: `xAccel.map(val => deviceId === 2 ? -val : val)`
- ESLint警告の修正とPrettierフォーマットの適用

## テスト結果
- [x] フロントエンドユニットテスト: 全て成功
- [x] 型チェック: エラーなし
- [x] ESLint: エラーなし
- [x] Prettier: フォーマット済み

🤖 Generated with [Claude Code](https://claude.ai/code)