### PR TITLE
ci: modernize GitHub Actions and add Docker build verification

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,61 @@
+# Root .dockerignore — applies to builds that use the repo root as context
+# (currently: frontend image build in CI and docker-compose).
+# Keep this conservative; per-service ignores still live at backend/.dockerignore
+# and frontend/.dockerignore.
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+.github/
+
+# Worktrees, local env
+.worktrees/
+.venv/
+venv/
+.env
+.env.local
+.env.*.local
+
+# Editor / tool caches
+.vscode/
+.idea/
+.cursor/
+.omc/
+.claude/
+.mypy_cache/
+.pytest_cache/
+.ruff_cache/
+.coverage
+coverage/
+coverage-*.xml
+
+# Node / pnpm
+node_modules/
+frontend/node_modules/
+frontend/dist/
+frontend/coverage/
+frontend/playwright-report/
+frontend/test-results/
+.pnpm-store/
+
+# Python
+__pycache__/
+*.pyc
+*.pyo
+*.egg-info/
+backend/.venv/
+backend/logs/
+
+# Docker / compose artifacts
+docker-compose.override.yml
+
+# Docs / logs
+README.md
+docs/
+logs/
+*.log
+
+# OS junk
+.DS_Store
+Thumbs.db

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,93 +7,120 @@ on:
     branches: [ main ]
 
 jobs:
-  test:
+  backend-lint-test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.12"]
 
     steps:
-    - uses: actions/checkout@v3
-    
+    - uses: actions/checkout@v4
+
     - name: Install system dependencies
       run: |
         sudo apt-get update
         sudo apt-get install -y portaudio19-dev
-    
+
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    
+
     - name: Install uv
       uses: astral-sh/setup-uv@v3
       with:
         enable-cache: true
         cache-dependency-glob: "**/pyproject.toml"
-    
+
     - name: Install dependencies
       working-directory: ./backend
       run: |
         uv venv
         uv pip install -e ".[dev,api]"
         uv pip install httpx
-    
+
     - name: Lint with black
       working-directory: ./backend
       run: |
-        uv run black --version
         uv run black --check src tests || (uv run black --diff src tests && exit 1)
-    
+
     - name: Lint with ruff
       working-directory: ./backend
       run: |
         uv run ruff check src tests
-    
+
     - name: Type check with mypy
       working-directory: ./backend
       run: |
         uv run mypy src --ignore-missing-imports || true
-    
+
     - name: Test with pytest
       working-directory: ./backend
       run: |
         uv run pytest tests -v --cov=src/haptic_system --cov-report=xml --cov-report=term
-    
+
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
-        file: ./coverage.xml
-        flags: unittests
-        name: codecov-umbrella
+        file: ./backend/coverage.xml
+        flags: backend
+        name: backend-coverage
         fail_ci_if_error: false
 
-  build-frontend:
+  frontend-lint-test:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    
+    - uses: actions/checkout@v4
+
     - name: Setup pnpm
-      uses: pnpm/action-setup@v2
+      uses: pnpm/action-setup@v4
       with:
         version: 10
-    
+
     - name: Use Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
-        node-version: '18.x'
+        node-version: '20.x'
         cache: 'pnpm'
         cache-dependency-path: pnpm-lock.yaml
-    
+
     - name: Install dependencies
       working-directory: ./frontend
       run: pnpm install --frozen-lockfile
-    
+
+    - name: Type check
+      working-directory: ./frontend
+      run: pnpm type-check
+
+    - name: Lint
+      working-directory: ./frontend
+      run: pnpm lint
+
     - name: Build
       working-directory: ./frontend
       run: pnpm build
-    
+
     - name: Test
       working-directory: ./frontend
       run: pnpm test --run
+
+  docker-build:
+    runs-on: ubuntu-latest
+    needs: [backend-lint-test, frontend-lint-test]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Validate docker-compose configs
+      run: |
+        docker compose -f docker-compose.yml config --quiet
+        docker compose -f docker-compose.dev.yml config --quiet
+
+    - name: Build backend image
+      run: |
+        docker build --target production -t yuragi-haptic-backend:ci ./backend
+
+    - name: Build frontend image
+      run: |
+        docker build --target production -t yuragi-haptic-frontend:ci ./frontend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,4 +123,4 @@ jobs:
 
     - name: Build frontend image
       run: |
-        docker build --target production -t yuragi-haptic-frontend:ci ./frontend
+        docker build --target production -t yuragi-haptic-frontend:ci -f frontend/Dockerfile .

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -28,6 +28,9 @@ ENV PATH="/venv/bin:$PATH"
 # Copy dependency files
 COPY pyproject.toml ./
 
+# Copy source tree so Hatchling can build the haptic-system wheel
+COPY src/ ./src/
+
 # Install uv for faster dependency resolution
 RUN pip install uv
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -41,7 +41,9 @@ services:
   # Frontend web service (development)
   frontend:
     build:
-      context: ./frontend
+      # Repo root context: Dockerfile needs pnpm-lock.yaml + pnpm-workspace.yaml
+      context: .
+      dockerfile: frontend/Dockerfile
       target: development
     image: yuragi-haptic-frontend:dev
     container_name: yuragi-frontend-dev
@@ -53,14 +55,14 @@ services:
       - VITE_API_BASE_URL=http://localhost:8000
       - VITE_WS_BASE_URL=ws://localhost:8000
     volumes:
-      - ./frontend/src:/app/src:ro
-      - ./frontend/public:/app/public:ro
-      - ./frontend/.env.development:/app/.env:ro
-      - ./frontend/package.json:/app/package.json:ro
-      - ./frontend/vite.config.ts:/app/vite.config.ts:ro
-      - ./frontend/tsconfig.json:/app/tsconfig.json:ro
-      - ./frontend/tsconfig.node.json:/app/tsconfig.node.json:ro
-      - frontend-node-modules:/app/node_modules
+      - ./frontend/src:/workspace/frontend/src:ro
+      - ./frontend/public:/workspace/frontend/public:ro
+      - ./frontend/.env.development:/workspace/frontend/.env:ro
+      - ./frontend/package.json:/workspace/frontend/package.json:ro
+      - ./frontend/vite.config.ts:/workspace/frontend/vite.config.ts:ro
+      - ./frontend/tsconfig.json:/workspace/frontend/tsconfig.json:ro
+      - ./frontend/tsconfig.node.json:/workspace/frontend/tsconfig.node.json:ro
+      - frontend-node-modules:/workspace/frontend/node_modules
     networks:
       - haptic-network
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,9 @@ services:
   # Frontend web service
   frontend:
     build:
-      context: ./frontend
+      # Repo root context: Dockerfile needs pnpm-lock.yaml + pnpm-workspace.yaml
+      context: .
+      dockerfile: frontend/Dockerfile
       target: production
     image: yuragi-haptic-frontend:latest
     container_name: yuragi-frontend

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,31 +1,37 @@
 # Multi-stage Dockerfile for Yuragi Haptic Generator Frontend
 # Optimized for production deployment with minimal image size
+#
+# IMPORTANT: This Dockerfile is designed to be built from the repo root
+# because the repo is a pnpm workspace: pnpm-lock.yaml, pnpm-workspace.yaml,
+# and .npmrc all live at the root, not inside ./frontend.
+# Build with:   docker build -f frontend/Dockerfile --target <stage> .
 
 # Build stage
 FROM node:20-alpine as builder
 
-# Set working directory
-WORKDIR /app
+WORKDIR /workspace
 
-# Set environment variables for build optimization
 ENV NODE_ENV=production \
     PNPM_HOME="/pnpm" \
     PATH="$PNPM_HOME:$PATH"
 
-# Install pnpm
-RUN corepack enable
+# Activate pnpm version pinned in frontend/package.json (packageManager field)
+RUN corepack enable && corepack prepare pnpm@9.1.0 --activate
 
-# Copy package files
-COPY package.json pnpm-lock.yaml ./
+# Copy workspace manifests first for cache-friendly install
+COPY pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+COPY frontend/package.json ./frontend/
 
-# Install dependencies
-RUN pnpm install --frozen-lockfile --prod=false
+# Install frontend deps (including devDependencies — tsc/vite needed for build)
+RUN pnpm install --frozen-lockfile --prod=false --filter "./frontend"
 
-# Copy source code
-COPY . .
+# Copy frontend source
+COPY frontend/ ./frontend/
 
-# Copy production environment file
-COPY .env.production .env
+WORKDIR /workspace/frontend
+
+# Use production env file at build time
+COPY frontend/.env.production .env
 
 # Build the application with production optimizations
 RUN pnpm run build:production
@@ -39,16 +45,14 @@ RUN apk update && apk upgrade && \
     rm -rf /var/cache/apk/*
 
 # Copy custom nginx configuration
-COPY nginx.conf /etc/nginx/nginx.conf
+COPY frontend/nginx.conf /etc/nginx/nginx.conf
 
 # Copy built application from builder stage
-COPY --from=builder /app/dist /usr/share/nginx/html
+COPY --from=builder /workspace/frontend/dist /usr/share/nginx/html
 
-# Create non-root user for nginx
-RUN addgroup -g 1001 -S nginx && \
-    adduser -S -D -H -u 1001 -h /var/cache/nginx -s /sbin/nologin -G nginx -g nginx nginx
+# nginx:alpine already provides the `nginx` user/group — reuse it.
 
-# Set ownership and permissions
+# Set ownership and permissions on dirs nginx needs to write/read
 RUN chown -R nginx:nginx /usr/share/nginx/html && \
     chown -R nginx:nginx /var/cache/nginx && \
     chown -R nginx:nginx /var/log/nginx && \
@@ -74,35 +78,29 @@ CMD ["nginx", "-g", "daemon off;"]
 # Development stage
 FROM node:20-alpine as development
 
-# Set working directory
-WORKDIR /app
+WORKDIR /workspace
 
-# Set environment variables
 ENV NODE_ENV=development \
     PNPM_HOME="/pnpm" \
     PATH="$PNPM_HOME:$PATH"
 
-# Install pnpm
-RUN corepack enable
+RUN corepack enable && corepack prepare pnpm@9.1.0 --activate
 
-# Copy package files
-COPY package.json pnpm-lock.yaml ./
+COPY pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+COPY frontend/package.json ./frontend/
 
-# Install all dependencies (including dev)
-RUN pnpm install --frozen-lockfile
+# Install all deps including dev
+RUN pnpm install --frozen-lockfile --filter "./frontend"
 
-# Copy source code
-COPY . .
+COPY frontend/ ./frontend/
 
-# Copy development environment file
-COPY .env.development .env
+WORKDIR /workspace/frontend
 
-# Expose port
+COPY frontend/.env.development .env
+
 EXPOSE 3000
 
-# Health check for development
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD curl -f http://localhost:3000/ || exit 1
 
-# Start development server
 CMD ["pnpm", "run", "dev", "--host", "0.0.0.0"]


### PR DESCRIPTION
## Summary

- Updated all GitHub Action versions to latest (checkout v4, setup-python v5, setup-node v4, pnpm/action-setup v4, codecov v4)
- Upgraded Node.js from 18.x to 20.x to match the project's Dockerfile (node:20-alpine)
- Added frontend type-check (`tsc --noEmit`) and lint (`eslint`) steps to CI
- Added `docker-build` job that validates docker-compose configs and builds both backend/frontend production images
- Fixed coverage XML path (was `./coverage.xml`, now `./backend/coverage.xml`)
- Renamed jobs for clarity: `test` → `backend-lint-test`, `build-frontend` → `frontend-lint-test`

## Test plan

- [ ] Verify `backend-lint-test` job passes (black, ruff, mypy, pytest)
- [ ] Verify `frontend-lint-test` job passes (type-check, lint, build, vitest)
- [ ] Verify `docker-build` job passes (compose config validation + image builds)
- [ ] Confirm coverage upload works with corrected path