### PR TITLE
fix(nginx): remove invalid gzip_proxied values (SCI-113)

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -69,6 +69,22 @@ The application uses multi-stage Docker builds:
 - **Production**: Optimized images with minimal dependencies
 - **Development**: Full development environment with hot reloading
 
+#### Frontend container requires Docker Compose networking
+
+The frontend nginx configuration (`frontend/nginx.conf`) uses `proxy_pass http://backend:8000`
+for both the `/api/` and `/ws` locations. The hostname `backend` is only resolvable on the
+Docker Compose service network. Running the frontend image with plain `docker run` fails at
+startup with `host not found in upstream "backend"`.
+
+Supported ways to run the frontend image:
+- `docker compose -f docker-compose.yml up` (recommended; resolves `backend` via the compose network).
+- Any orchestrator that provides a DNS record for a service named `backend` on port `8000`.
+
+Do **not** run `docker run ghcr.io/.../frontend` as a standalone smoke test — it is expected to
+fail upstream resolution. For CI smoke-testing, build and validate config with
+`docker run --rm --add-host backend:127.0.0.1 -v ./frontend/nginx.conf:/etc/nginx/nginx.conf:ro
+nginx:alpine nginx -t` (syntax check only).
+
 ## Deployment Scripts
 
 ### Main Deployment Script (`scripts/deploy.sh`)

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -55,7 +55,7 @@ http {
     gzip on;
     gzip_vary on;
     gzip_min_length 10240;
-    gzip_proxied expired no-cache no-store private must-revalidate no-transform auth;
+    gzip_proxied expired no-cache no-store private auth;
     gzip_types
         text/plain
         text/css


### PR DESCRIPTION
## Summary

Fix a pre-existing runtime bug in `frontend/nginx.conf` that caused nginx to fail to start in the production image:

```
nginx: [emerg] 1#1: invalid value "must-revalidate" in /etc/nginx/nginx.conf:58
```

`must-revalidate` and `no-transform` are Cache-Control header values, **not** valid values for the `gzip_proxied` directive. The valid set per nginx docs is: `off | expired | no-cache | no-store | private | no_last_modified | no_etag | auth | any`.

### Change

```diff
-    gzip_proxied expired no-cache no-store private must-revalidate no-transform auth;
+    gzip_proxied expired no-cache no-store private auth;
```

Also adds a short section in `DEPLOYMENT.md` clarifying that the frontend image requires the Docker Compose service network (the `backend` hostname in `proxy_pass http://backend:8000` only resolves on the compose network). This was raised as a follow-up in SCI-113 so that `docker run` on the image without compose is not mistaken for a bug.

## Context

Spun off from PR #21 / SCI-41 (CI pipeline work). PR #21 fixed `frontend/Dockerfile` and surfaced this pre-existing nginx misconfiguration while smoke-testing the built image. This PR is scope-separated from #21 and does not block that merge.

Tracking issue: SCI-113 (priority: medium)

## Test plan

- [x] `docker run --rm --add-host backend:127.0.0.1 -v ./frontend/nginx.conf:/etc/nginx/nginx.conf:ro --entrypoint sh nginx:alpine -c "mkdir -p /var/run/nginx && nginx -t"` returns `syntax is ok` + `test is successful`
- [ ] `docker compose -f docker-compose.yml up` starts frontend without `emerg`, `/health` returns 200 (reviewer)
- [ ] CI pipeline green

🤖 Generated with Paperclip